### PR TITLE
Update socket filter to PoE 2 syntax

### DIFF
--- a/NeverSinks Litefilter.filter
+++ b/NeverSinks Litefilter.filter
@@ -235,7 +235,7 @@ SetFontSize 40
 
 # Not working!
 Show
-Sockets > 0
+Sockets S
 Rarity Normal
 SetBorderColor 200 200 200
 SetFontSize 35
@@ -248,7 +248,7 @@ SetFontSize 35
 
 # Not working!
 Show
-Sockets > 0
+Sockets S
 Rarity Magic
 SetBorderColor 0 0 200
 SetFontSize 35


### PR DESCRIPTION
Don't remember where I saw it, probably on the forums, but for some reason the correct syntax for "Any item with sockets" on PoE 2 is `Sockets S`. I tested it locally and it works fine.