### PR TITLE
Remove style mention in "how to install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download the latest release from github.
 
 0) Get the latest filter file from [GitHub](https://github.com/NeverSinkDev/NeverSink-PoE2litefilter/releases/latest).
 1) Extract the files using 7zip or a similar tool.
-2) Paste the .filter files (or just the folder content, if you want to use a specific style, paste the files from one of the (STYLE) folders instead) into the following folder:
+2) Paste the `NeverSinks Litefilter.filter` file into the following folder:
    - Windows: `%userprofile%\Documents\My Games\Path of Exile 2`
    - Linux: `steamapps/compatdata/2694490/pfx/drive_c/users/steamuser/My Documents/My Games/Path of Exile 2`
 4) INGAME: Escape -> Options -> Game -> Filters -> Select one of the filters from the dropdown box.


### PR DESCRIPTION
Styles are not a part of this lite filter, so I removed that part from the install steps in order to avoid confusion.