### PR TITLE
Created .gitattributes for .filter text coloring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Linguist Docs: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#using-gitattributes
+
+# Set filter files to INI (coloring) in PRs
+*.filter linguist-language=INI


### PR DESCRIPTION
## Summary

When you add a `.gitattributes` file to a GitHub repo, it will recognize the settings in it. Here, I've made it so that the `*.filter` files have some kind of coloring to them, instead of just being plain text when viewing. After some testing, I found `*.ini` to be the closest format to that of the `*.filter` files.

## Docs

https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#using-gitattributes

## Example

Viewing the current `.filter` file on my branch shows like this. Note that I'm using dark mode so it'll likely look different to others.

![image](https://github.com/user-attachments/assets/33562bcd-c3d6-4641-b995-0d3484a0afae)