### PR TITLE
Add filter rule for body armour with implicits

### DIFF
--- a/NeverSinks Litefilter.filter
+++ b/NeverSinks Litefilter.filter
@@ -407,6 +407,18 @@ Rarity Magic
 SetFontSize 40
 
 #--------------------------
+# High Level Implicit Body Armours
+# Has a free extra mod for crafting endgame gear
+#--------------------------
+Show
+Class "Body Armours"
+DropLevel >= 65
+HasImplicitMod True
+SetFontSize 40
+SetTextColor 233 206 75
+SetBorderColor 233 206 75
+
+#--------------------------
 # Salvagable Items
 #--------------------------
 


### PR DESCRIPTION
Only relevant for high levels maps, but armour with implicits are useful for crafting 7-mod gear. They sell for 1ex at the very worst