### PR TITLE
Tablet Class

### DIFF
--- a/NeverSinks Litefilter.filter
+++ b/NeverSinks Litefilter.filter
@@ -328,7 +328,17 @@ MinimapIcon 1 Yellow Square
 SetFontSize 40
 
 Show
-BaseType "Simulacrum" " Tablet" "Breachstone" "Cowardly Fate" "Deadly Fate" "Victorious Fate" "Expedition Logbook" "Test of"
+BaseType "Simulacrum" "Breachstone" "Cowardly Fate" "Deadly Fate" "Victorious Fate" "Expedition Logbook" "Test of"
+SetTextColor 255 207 255
+SetBorderColor 255 207 255
+SetBackgroundColor 65 20 80
+PlayAlertSound 2 300
+PlayEffect Purple
+MinimapIcon 1 Purple Square
+SetFontSize 45
+
+Show
+Class  " Tablet"
 SetTextColor 255 207 255
 SetBorderColor 255 207 255
 SetBackgroundColor 65 20 80


### PR DESCRIPTION
Precursor tablets are also their own class of item, and not working with the basetype thing.... Same as before just thrown another rule copying the style etc of the existing one