### PR TITLE
Fix Quality salvagable items rule

### DIFF
--- a/NeverSinks Litefilter.filter
+++ b/NeverSinks Litefilter.filter
@@ -427,7 +427,7 @@ SetBorderColor 200 200 200
 SetFontSize 35
 
 Show
-Quality > 1
+Quality >= 1
 Rarity Normal
 SetBorderColor 200 200 200
 SetFontSize 35
@@ -439,7 +439,7 @@ SetBorderColor 0 0 200
 SetFontSize 35
 
 Show
-Quality > 1
+Quality >= 1
 Rarity Magic
 SetBorderColor 0 0 200
 SetFontSize 35


### PR DESCRIPTION
Not sure if this is a mistake, but does item with quality of 1% invalid for salvage?

P.S. Thanks for the filter!
P.S.S. Do you happen to know if the "Import" block does not work? I wanted to have my own edits on top of yours in a separate file, but it seems like `Import "your.filter"` does not work (looked for "Import" block here https://www.pathofexile.com/item-filter/about).
