### PR TITLE
Give Level 20 gems proper highlighting

### DIFF
--- a/NeverSinks Litefilter.filter
+++ b/NeverSinks Litefilter.filter
@@ -79,6 +79,18 @@ SetBackgroundColor 0 0 0 180
 # Uncut Gems
 #--------------------------
 
+# Level 20 gems go tink
+Show
+ItemLevel = 20
+BaseType "Uncut Skill Gem" "Uncut Spirit Gem"
+SetFontSize 45
+SetTextColor 255 0 0 255
+SetBorderColor 255 0 0 255
+SetBackgroundColor 255 255 255 255
+PlayAlertSound 6 300
+PlayEffect Red
+MinimapIcon 0 Red Star
+
 # Always make Spirit gems pop
 Show
 BaseType "Uncut Spirit Gem"


### PR DESCRIPTION
Uncut skill gems go for 3 div on trade, spirit ones for 5. This gives them the highlighing and sound of divine orbs.